### PR TITLE
Add label to limit max log quantity

### DIFF
--- a/addons/loggie-console/scenes/console.gd
+++ b/addons/loggie-console/scenes/console.gd
@@ -8,8 +8,12 @@ class_name LoggieConsole extends Window
 
 @export var scroll_follow: Button
 
+@export var max_messages_input: LineEdit
+var messages: Array[String] = []
+const MAX_MESSAGES_DEFAULT : int = 500
+
 @export_category("Collapse")
-@export var collapse_texture: Texture2D
+@export var collapse_texture: Texture2D 
 @export var uncollapse_texture: Texture2D
 var collapsed := false
 
@@ -56,9 +60,24 @@ func _ready() -> void:
 	)
 	buffer.scroll_following = scroll_follow.button_pressed
 
-func _on_log_attempted(msg : LoggieMsg, preprocessed_content : String, result : LoggieEnums.LogAttemptResult):
+	max_messages_input.text_changed.connect(_on_max_messages_changed)
+
+func _on_log_attempted(msg: LoggieMsg, preprocessed_content: String, result: LoggieEnums.LogAttemptResult):
 	if result == LoggieEnums.LogAttemptResult.SUCCESS:
-		buffer.text += preprocessed_content + "\n"
+		messages.append(preprocessed_content)
+
+		var max_messages: int = int(max_messages_input.text) if max_messages_input.text.is_valid_int() else MAX_MESSAGES_DEFAULT
+
+		if messages.size() > max_messages:
+			messages.pop_front()
+
+		buffer.text = "\n".join(messages)
+
+func _on_max_messages_changed(_new_text: String) -> void:
+	var max_messages: int = int(max_messages_input.text) if max_messages_input.text.is_valid_int() else MAX_MESSAGES_DEFAULT
+	while messages.size() > max_messages:
+		messages.pop_front()
+	buffer.text = "\n".join(messages)
 
 func _expand_console() -> void:
 	collapsed = false

--- a/addons/loggie-console/scenes/console.tscn
+++ b/addons/loggie-console/scenes/console.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="Theme" uid="uid://f7mt8kavlkap" path="res://addons/loggie-console/theme.tres" id="4_2cgp1"]
 [ext_resource type="Texture2D" uid="uid://bks24limepbma" path="res://addons/loggie-console/assets/trash.svg" id="4_ptot7"]
 
-[node name="LoggieConsoleWindow" type="Window" node_paths=PackedStringArray("buffer", "output_level", "clear", "scroll_follow")]
+[node name="LoggieConsoleWindow" type="Window" node_paths=PackedStringArray("buffer", "output_level", "clear", "scroll_follow", "max_messages_input")]
 title = "Loggie Console"
 initial_position = 1
 size = Vector2i(1000, 500)
@@ -17,6 +17,7 @@ buffer = NodePath("Panel/MarginContainer/VBoxContainer/Buffer")
 output_level = NodePath("Panel/MarginContainer/VBoxContainer/Controls/OutputLevel")
 clear = NodePath("Panel/MarginContainer/VBoxContainer/Controls/Clear")
 scroll_follow = NodePath("Panel/MarginContainer/VBoxContainer/Controls/ScrollFollow")
+max_messages_input = NodePath("Panel/MarginContainer/VBoxContainer/Controls/HBoxContainer/LineEdit")
 collapse_texture = ExtResource("3_i3phv")
 uncollapse_texture = ExtResource("2_7iokb")
 
@@ -56,6 +57,20 @@ layout_mode = 2
 size_flags_horizontal = 10
 button_pressed = true
 text = "Follow"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="Panel/MarginContainer/VBoxContainer/Controls"]
+layout_mode = 2
+
+[node name="VSeparator" type="VSeparator" parent="Panel/MarginContainer/VBoxContainer/Controls/HBoxContainer"]
+layout_mode = 2
+
+[node name="Label" type="Label" parent="Panel/MarginContainer/VBoxContainer/Controls/HBoxContainer"]
+layout_mode = 2
+text = "Max Lines"
+
+[node name="LineEdit" type="LineEdit" parent="Panel/MarginContainer/VBoxContainer/Controls/HBoxContainer"]
+layout_mode = 2
+text = "100"
 
 [node name="Buffer" type="RichTextLabel" parent="Panel/MarginContainer/VBoxContainer"]
 layout_mode = 2


### PR DESCRIPTION
The extension is very good to have a console accessible from the build. It works very well but has a problem in a roundabout way.

If you generate a lot of logs it ends up generating a memory problem. I have made a simple solution which consists in limiting the maximum amount of logs.

By the way, if I have some more time I will try to implement a collapse to attach commits in blocks, but no promises.